### PR TITLE
Improve domain comments and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,45 @@
-![CI](https://github.com/<owner>/<repo>/actions/workflows/ci.yml/badge.svg?branch=public)
-
-![Release](https://img.shields.io/github/v/release/<owner>/<repo>?include_prereleases&label=release)
-
-
 # Home Teach App
 
-Home Teach App は、学習塾の運営を想定した Django 製の業務支援システムです。管理者・講師・生徒の 3 つのポータルを備え、授業スケジュール、カルテ提出、報酬計算、アカウント管理が 1 つのアプリで完結します。本リポジトリはポートフォリオ公開を想定した安全な構成とドキュメントを含みます。
+Home Teach App は、学習塾の運営を支援する Django 製の業務システムです。管理者・講師・生徒向けの 3 つのポータルを備え、授業スケジュール管理からカルテ提出、報酬締めまでを同一アプリで完結できます。ポートフォリオ公開を想定し、安全にデモ公開できる設定やドキュメントも含めています。
 
-## Overview
+## 機能ハイライト
+- **管理者ポータル**: 講師・生徒アカウントの発行、担当割り当て、授業スケジュールの編集、報酬締め処理、CSV / PDF 出力に対応しています。
+- **講師ポータル**: 直近授業のダッシュボード表示、授業カルテの下書き・提出、過去授業の検索、授業カルテ PDF のダウンロードが可能です。
+- **生徒ポータル**: 自身の授業予定をカレンダー順に閲覧できます。
+- **運用補助機能**: デモ用の読み取り専用モード、強制パスワード変更、アクセスログ／ダウンロードログの保存、監査向けミドルウェアなどを実装しています。
 
-- **Multi-portal UI**: `/admin_portal`, `/teacher_portal`, `/student_portal` で役割に応じたダッシュボードを提供。
-- **Reward & schedule operations**: 授業カルテの提出状況に応じて報酬を集計し、締め処理や PDF 出力が可能。
-- **Account lifecycle management**: 管理者は講師・生徒アカウントを登録・編集・削除でき、確認画面つきで安全に運用できます。
-- **Hardening for demos**: 読み取り専用モード、強制パスワード変更、監査ログなどコンプライアンス機能を内蔵。
-- **Bilingual docs**: 英語 / 日本語でセットアップ手順を用意し、公開デモや面談時の説明に活用できます。
-
-## Tech Stack
-
+## 技術スタック
 - Django 5.2 / Python 3.12
-- SQLite (デフォルト) — `.env` で他の DB に切り替え可能
-- HTML templates + Bootstrap + Alpine.js (最小限のインタラクション)
-- Pytest ベースの統合テスト (`tests/`)
+- SQLite (標準) ― `.env` で PostgreSQL などに切り替え可能
+- Django Templates + Bootstrap + Alpine.js（最小限の動的挙動）
+- Pytest による統合テスト (`tests/`)
 
-## Project Structure
-
+## ディレクトリ構成
 ```
-admin_portal/  … 管理者向け機能（登録、報酬締め、PDF 出力 など）
-teacher_portal/ … 授業カルテ提出やスケジュール調整
-student_portal/ … 生徒用の閲覧 UI
-personal_info/ … ドメインモデル（TeacherProfile, ClassSchedule, …）
-core/          … 共通ロジック（ミドルウェア、ユーティリティ、管理コマンド）
-docs/          … 運用手順やバックアップドリル
+admin_portal/   … 管理者向けビュー・フォーム
+teacher_portal/ … 講師向けビュー・PDF 出力ユーティリティ
+student_portal/ … 生徒向けビュー
+personal_info/  … 主要モデル（講師・生徒・授業・カルテ・報酬集計など）
+core/           … 共通ロジック（ミドルウェア、ユーザープロファイル、管理コマンド）
+docs/           … 運用手順やバックアップに関するドキュメント
 ```
 
-## Quickstart (Local Development)
-
+## ローカル開発の始め方
 ```bash
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 cp .env.example .env
 python manage.py migrate
-python manage.py createsuperuser
+python manage.py createsuperuser  # 管理者アカウントを任意で作成
 python manage.py runserver
 ```
 
-- `.env` の `DJANGO_SECRET_KEY`、`DJANGO_ALLOWED_HOSTS` を自身の環境に合わせて変更。
-- `python manage.py createsuperuser` で開発用のアカウントを作成（任意で `seed_demo` コマンドを実行するとデモデータを投入可能）。
+- `.env` の `DJANGO_SECRET_KEY` や `DJANGO_ALLOWED_HOSTS` を自分の環境に合わせて更新してください。
+- デモ用の ID を用意したい場合は `python manage.py seed_demo` を実行します（`A_demo` と `T_demo` ユーザーが作成され、パスワードは `Demo!Pass1` です）。必要に応じて管理者ポータルから講師/生徒プロフィールを登録してください。
 
-## Demo Mode (Optional Public Sandbox)
-
-デモ公開時は環境変数 `DJANGO_SETTINGS_MODULE=config.settings_demo` を指定して起動します。読み取り専用モードや管理画面の秘匿 URL など、公開前提でのハードニングが有効化されます（管理者ロールは必要な削除操作も継続して実行できます）。
+## Demo モード（公開サンドボックス向け）
+デモ公開時は環境変数 `DJANGO_SETTINGS_MODULE=config.settings_demo` を指定して起動します。読み取り専用モードや秘匿管理 URL など、公開運用を想定したハードニングが有効化されます。
 
 ```bash
 export DJANGO_SETTINGS_MODULE=config.settings_demo
@@ -59,19 +48,18 @@ python manage.py seed_demo
 python manage.py runserver 127.0.0.1:8000
 ```
 
-| Account | Role | Notes |
-|---------|------|-------|
-| `A_demo / Demo!Pass1` | Staff (non-superuser) | 書き込みが可能な仮管理者 |
-| `T_demo / Demo!Pass1` | Teacher | 読み取り専用が基本 |
+| Account | Role | 備考 |
+|---------|------|------|
+| `A_demo / Demo!Pass1` | スタッフ（非スーパーユーザー） | デモ用管理者。主要機能の編集が可能 |
+| `T_demo / Demo!Pass1` | Teacher | 既存授業のカルテ編集が中心。読み取り専用が基本 |
 
-- ホスト名は `DEMO_HOSTS` (複数可) または `DEMO_HOST` で指定できます。未設定時でも `localhost` / `127.0.0.1` からアクセスできます。
+- 許可するホスト名は `DEMO_HOSTS`（複数可）または `DEMO_HOST` で設定します。未設定の場合でも `localhost` / `127.0.0.1` からアクセスできます。
 - HTTPS を強制できないローカル検証では `DEMO_FORCE_HTTPS=false` を指定してください。
 - デモ用管理サイトは `ADMIN_URL` 環境変数で指定したパスにマウントされます（例: `admin-8c1b3f1c/`）。公開資料に直接記載しないでください。
-- `python manage.py reset_demo` で DB の初期化とデモデータの再投入が実行されます。cron を利用して定期実行することで閲覧用データをクリーンに保てます。
+- `python manage.py reset_demo` でデータベースを初期化し、デモユーザーを再投入できます。定期的な実行で閲覧用データをクリーンに保てます。
 
-## Production Deployment
-
-本番運用時は `config/settings_prod.py` を利用し、HTTPS 前提のセキュリティ設定を有効化します。
+## 本番運用のポイント
+本番環境では `config/settings_prod.py` を利用し、HTTPS 前提のセキュリティ設定を有効化します。
 
 ```bash
 export DJANGO_SETTINGS_MODULE=config.settings_prod
@@ -84,34 +72,21 @@ python manage.py migrate
 python manage.py check --deploy
 ```
 
-- `SECURE_SSL_REDIRECT` / HSTS などの値は環境変数で上書き可能です（`.env.example` を参照）。
-- リバースプロキシ経由で TLS 終端する場合は `SECURE_PROXY_SSL_HEADER` が適切に設定されているか確認してください。
-- 上記コマンドは Django を公開する前に一度実行し、警告が解消されていることを確認します。
+- `SECURE_SSL_REDIRECT` や HSTS の値は環境変数で上書きできます（`.env.example` を参照）。
+- リバースプロキシ経由で TLS を終端する場合は `SECURE_PROXY_SSL_HEADER` が正しく設定されているか確認してください。
+- 公開前に `python manage.py check --deploy` を実行し、警告が出ないことを確認してください。
 
-## Running Tests
-
+## テスト
 ```bash
 pytest
 ```
 
-代表的なユースケース（カルテ提出、報酬締め、アクセス制御 など）をカバーする統合テストを含みます。Pull Request での品質担保に利用してください。
+授業カルテ提出フローやアクセス制御など主要ユースケースをカバーする統合テストが含まれています。Pull Request 時の回帰確認に活用できます。
 
-## Portfolio Tips
-
-- デモ環境は read-only が基本のため、面談ではスタッフ権限アカウントを共有し、特定の機能のみ編集できる点を説明すると安心感を与えられます。
-- テンプレートは Bootstrap ベースなので、必要に応じて UI スクリーンショットを `docs/` 配下に追加すると説明資料が整います。
-- デプロイ時は `.env` に本番用シークレットを設定し、`DJANGO_DEBUG=False` に変更してください。
-
-## 日本語セットアップガイド
-
-1. `python -m venv venv` → `source venv/bin/activate`
-2. `pip install -r requirements.txt`
-3. `.env.example` を `.env` にコピーし、`DJANGO_SECRET_KEY` を任意の値に変更
-4. `python manage.py migrate`
-5. `python manage.py seed_demo` または `python manage.py createsuperuser`
-6. `python manage.py runserver 127.0.0.1:8000`
-
-注意: 公開デモの場合は個人情報を入力しないよう、README や実際の画面に注意書きを表示してください。
+## 補足情報
+- デモ環境は原則読み取り専用です。面談などで編集操作を見せる場合はスタッフ権限アカウントを共有し、操作範囲をあらかじめ説明すると安心感を与えられます。
+- テンプレートは Bootstrap ベースなので、必要に応じて UI のスクリーンショットを `docs/` 配下に追加すると説明資料が整います。
+- 公開環境では `.env` に本番用シークレットを設定し、`DJANGO_DEBUG=False` に変更してください。
 
 ---
 

--- a/admin_portal/forms.py
+++ b/admin_portal/forms.py
@@ -35,11 +35,11 @@ class TeacherRegistForm(forms.ModelForm):
 
     @transaction.atomic
     def save(self, commit=True):
-        #ランダムID生成
+        # ランダムなユーザーIDを発行する
         username = generate_user_id("T")
         raw_password = generate_compliant_password(12)
 
-        #UserとProfileの登録
+        # 認証ユーザーと関連する UserProfile を作成
         user = User.objects.create_user(username=username, password=raw_password)
         profile, _ = UserProfile.objects.get_or_create(user=user)
         profile.user_type = "teacher"
@@ -53,12 +53,12 @@ class TeacherRegistForm(forms.ModelForm):
             "is_locked",
         ])
 
-        #Teacher情報の登録
+        # TeacherProfile 本体を保存
         teacher = super().save(commit=False)
         teacher.user = user
         if commit:
             teacher.save()
-            self.save_m2m()  # subjectsの ManyToMnay 保存
+            self.save_m2m()  # subjects の ManyToMany 関係を保存
         return user, raw_password
 
 class StudentRegistForm(forms.ModelForm):
@@ -103,7 +103,7 @@ class StudentRegistForm(forms.ModelForm):
         student.user = user
         if commit:
             student.save()
-            self.save_m2m()  # subjectsの ManyToMnay 保存
+            self.save_m2m()  # subjects の ManyToMany 関係を保存
         return user, raw_password
     
 class ScheduleSearchForm(forms.Form):
@@ -114,16 +114,16 @@ class ScheduleSearchForm(forms.Form):
 class RewardCategoryForm(forms.ModelForm):
     class Meta:
         model = RewardCategory
-        fields = ['category', 'reward_per_class']  # ← categoryは表示するが…
+        fields = ['category', 'reward_per_class']  # カテゴリ値は表示のみ
         widgets = {
             'reward_per_class': forms.NumberInput(attrs={'class': 'form-control', 'min': '0'}),
         }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # ← Djangoのフィールド側で disabled を指定（POST値は無視して instance 値が使われる）
+        # カテゴリ種別は変更不可のためフォームからの更新を禁止
         self.fields['category'].disabled = True
-        # styling
+        # 表示を Bootstrap に合わせる
         self.fields['category'].widget.attrs.update({'class': 'form-select'})
 
     def clean_reward_per_class(self):
@@ -203,7 +203,7 @@ class RewardCategoryCreateForm(forms.ModelForm):
         # 何も残っていない場合はメッセージを表示用に help_text を付与
         if not remain:
             self.fields['category'].help_text = 'すべてのカテゴリが作成済みです。'
-        # styling for reward_per_class
+        # 報酬額入力欄も Bootstrap のスタイルに合わせる
         self.fields['reward_per_class'].widget = forms.NumberInput(attrs={'class': 'form-control', 'min': '0'})
 
     def clean(self):

--- a/admin_portal/views.py
+++ b/admin_portal/views.py
@@ -1,4 +1,4 @@
-#管理者のみアクセスできる機能全般
+"""管理者ポータルで利用するビュー群。"""
 
 import csv, io
 from types import SimpleNamespace
@@ -141,7 +141,8 @@ def student_register(request):
         form = StudentRegistForm()
     return render(request, 'admin_portal/students/student_register.html', {'form': form})
 
-def is_admin(user): #アカウントがログインされていてかつ管理者か区別
+def is_admin(user):
+    """ログイン済みユーザーが管理者アカウントか判定する。"""
     return user.is_authenticated and hasattr(user, 'userprofile') and user.userprofile.user_type == 'admin'
 
 @login_required
@@ -185,7 +186,7 @@ def reset_user_password(request, user_id):
         return forbidden
     user = get_object_or_404(User, id=user_id)
 
-    new_password = generate_compliant_password(length=12)  # ← 差し替え
+    new_password = generate_compliant_password(length=12)  # ランダムな仮パスワードを再発行
     user.set_password(new_password)
     user.save()
 

--- a/personal_info/forms.py
+++ b/personal_info/forms.py
@@ -8,6 +8,8 @@ from .models import (
     MaterialUsage,
     TeacherStudentAssignment,
 )
+
+
 class SubjectForm(forms.ModelForm):
     class Meta:
         model = Subject
@@ -35,12 +37,16 @@ class ClassScheduleForm(forms.ModelForm):
     class Meta:
         model = ClassSchedule
         fields = [
-            "teacher", "student", "subject",
-            "class_date", "start_time", "end_time",
-            "status",              # ← ここに置換
-            "material",            # （モデルにあるなら残す）
-            "karte_summary",       # （モデルにあるなら残す）
-            "karte_detail",        # （モデルにあるなら残す）
+            "teacher",
+            "student",
+            "subject",
+            "class_date",
+            "start_time",
+            "end_time",
+            "status",
+            "material",
+            "karte_summary",
+            "karte_detail",
             "notes",
         ]
         widgets = {
@@ -52,7 +58,7 @@ class ClassScheduleForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
-        #科目と生徒が存在しているの確認
+        # 科目と生徒の組み合わせが分かれば教材候補を絞り込む
         subject = self.instance.subject if self.instance else None
         student = None
         if self.instance and hasattr(self.instance, 'student_id'):
@@ -62,16 +68,16 @@ class ClassScheduleForm(forms.ModelForm):
                 student = None
 
         if subject and student:
-            # 生徒が過去に使った教材（subject付き）を取得
+            # 生徒が過去に使った教材（科目付き）を取得
             used_materials = TeachingMaterial.objects.filter(
                 id__in=MaterialUsage.objects.filter(student=student).values_list('material_id', flat=True),
                 subject=subject
             )
 
-            # その他の教材（subject付き）で未使用のもの
+            # まだ使っていない同科目の教材
             unused_materials = TeachingMaterial.objects.filter(subject=subject).exclude(id__in=used_materials)
 
-            # 優先順でクエリセットを結合
+            # 既存利用済みを優先して並べ替える
             combined_qs = list(used_materials) + list(unused_materials)
             self.fields['material'].queryset = TeachingMaterial.objects.filter(id__in=[m.id for m in combined_qs])
 

--- a/personal_info/models.py
+++ b/personal_info/models.py
@@ -4,59 +4,79 @@ from django.contrib.auth.models import User
 from django.core.validators import MinValueValidator
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+
+
 TEACHER_GRADE = [
-    ('college_1', '大学１年生'),('college_2', '大学２年生'),('college_3', '大学３年生'),
-    ('college_4', '大学４年生'),('working_adult', '社会人'),
+    ("college_1", "大学１年生"),
+    ("college_2", "大学２年生"),
+    ("college_3", "大学３年生"),
+    ("college_4", "大学４年生"),
+    ("working_adult", "社会人"),
 ]
 
 STUDENT_GRADE = [
-    ('elementary_1', '小学１年生'),('elementary_2', '小学２年生'),('elementary_3', '小学３年生'),
-    ('elementary_4', '小学４年生'),('elementary_5', '小学５年生'),('elementary_6', '小学６年生'),
-    ('junior_1', '中学１年生'),('junior_2', '中学２年生'),('junior_3', '中学３年生'),
-    ('senior_1', '高校１年生'),('senior_2', '高校２年生'),('senior_3', '高校３年生'),
-    ('graduate', '既卒'),
+    ("elementary_1", "小学１年生"),
+    ("elementary_2", "小学２年生"),
+    ("elementary_3", "小学３年生"),
+    ("elementary_4", "小学４年生"),
+    ("elementary_5", "小学５年生"),
+    ("elementary_6", "小学６年生"),
+    ("junior_1", "中学１年生"),
+    ("junior_2", "中学２年生"),
+    ("junior_3", "中学３年生"),
+    ("senior_1", "高校１年生"),
+    ("senior_2", "高校２年生"),
+    ("senior_3", "高校３年生"),
+    ("graduate", "既卒"),
 ]
 
+
 class Subject(models.Model):
+    """指導科目を表すマスターモデル。"""
+
     name = models.CharField(max_length=50, unique=True)
 
     def __str__(self):
         return self.name
-    
-#講師報酬定義
+
+
 class RewardCategory(models.Model):
+    """講師報酬の区分と単価を管理する。"""
+
     CATEGORY_CHOICES = [
-        ('elementary', '小学生'),
-        ('junior', '中学生'),
-        ('high', '高校生'),
-        ('custom', '金額自由設定'),
+        ("elementary", "小学生"),
+        ("junior", "中学生"),
+        ("high", "高校生"),
+        ("custom", "金額自由設定"),
     ]
     category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, unique=True)
     reward_per_class = models.IntegerField(blank=True, null=True, verbose_name="１コマ当たりの報酬額")
 
     def __str__(self):
         return f"{self.get_category_display()} : ￥{self.reward_per_class or '自由設定'}"
-    
 
 
-#使用教材情報定義    
 class TeachingMaterial(models.Model):
-    title = models.CharField(max_length=100, unique=True, verbose_name='教材名')
-    subject = models.ForeignKey('Subject', on_delete=models.SET_NULL, null=True, blank=True, verbose_name="関連科目")
-    grade = models.CharField(max_length=50, choices=STUDENT_GRADE, blank=True, verbose_name='推奨学年')
-    publisher = models.CharField(max_length=100, blank=True, verbose_name='出版社')
-    description = models.TextField(blank=True, verbose_name='説明（空欄可）')
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL,on_delete=models.CASCADE, verbose_name='教材情報登録者')
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name='教材情報登録月日')
+    """授業で利用する教材の情報。"""
+
+    title = models.CharField(max_length=100, unique=True, verbose_name="教材名")
+    subject = models.ForeignKey("Subject", on_delete=models.SET_NULL, null=True, blank=True, verbose_name="関連科目")
+    grade = models.CharField(max_length=50, choices=STUDENT_GRADE, blank=True, verbose_name="推奨学年")
+    publisher = models.CharField(max_length=100, blank=True, verbose_name="出版社")
+    description = models.TextField(blank=True, verbose_name="説明（空欄可）")
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, verbose_name="教材情報登録者")
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name="教材情報登録月日")
 
     def __str__(self):
         return self.title
 
-#管理者情報定義
+
 class AdminProfile(models.Model):
+    """管理者ユーザーの基本情報。"""
+
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=100, blank=False)
-    gender = models.CharField(max_length=6, choices=[('man', '男性'), ('female', '女性')], blank=False)
+    gender = models.CharField(max_length=6, choices=[("man", "男性"), ("female", "女性")], blank=False)
     age = models.PositiveIntegerField(validators=[MinValueValidator(18)], blank=False)
     address = models.CharField(max_length=100, blank=False)
     phone = models.CharField(max_length=13, blank=False)
@@ -65,11 +85,13 @@ class AdminProfile(models.Model):
     def __str__(self):
         return self.name
 
-#講師情報定義 
+
 class TeacherProfile(models.Model):
+    """講師ユーザーに紐づく詳細プロフィール。"""
+
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=100, blank=False)
-    gender = models.CharField(max_length=6, choices=[('man', '男性'), ('female', '女性')])
+    gender = models.CharField(max_length=6, choices=[("man", "男性"), ("female", "女性")])
     age = models.PositiveIntegerField(validators=[MinValueValidator(18)], blank=False)
     address = models.CharField(max_length=1000, blank=False)
     phone = models.CharField(max_length=13, blank=False)
@@ -81,11 +103,13 @@ class TeacherProfile(models.Model):
     def __str__(self):
         return self.name
 
-#生徒情報定義
+
 class StudentProfile(models.Model):
+    """生徒ユーザーに紐づく詳細プロフィール。"""
+
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=100, blank=False)
-    gender = models.CharField(max_length=6, choices=[('man', '男性'), ('female', '女性')])
+    gender = models.CharField(max_length=6, choices=[("man", "男性"), ("female", "女性")])
     age = models.PositiveIntegerField(validators=[MinValueValidator(6)], blank=False)
     address = models.CharField(max_length=100, blank=False)
     phone = models.CharField(max_length=13, blank=False)
@@ -99,17 +123,18 @@ class StudentProfile(models.Model):
 
     def __str__(self):
         return self.name
-    
+
     def clean(self):
-        if self.reward_category and self.reward_category.category == 'custom':
+        if self.reward_category and self.reward_category.category == "custom":
             if not self.custom_reward_per_class:
                 raise ValidationError("金額自由設定の場合は報酬額の入力が必要です。")
 
 
 class TeacherStudentAssignment(models.Model):
+    """講師と生徒の担当関係および担当科目。"""
+
     teacher = models.ForeignKey("TeacherProfile", on_delete=models.CASCADE)
     student = models.ForeignKey("StudentProfile", on_delete=models.CASCADE)
-    # この講師-生徒の担当科目（複数可）
     subjects = models.ManyToManyField("Subject", blank=True, related_name="ts_assignments")
 
     class Meta:
@@ -122,8 +147,10 @@ class TeacherStudentAssignment(models.Model):
         s = getattr(self.student, "name", str(self.student_id))
         return f"{t} → {s}"
 
-#授業情報定義
+
 class ClassSchedule(models.Model):
+    """授業の予定および実施状況を保持する。"""
+
     teacher = models.ForeignKey(
         TeacherProfile, on_delete=models.SET_NULL, null=True, blank=True
     )
@@ -137,22 +164,25 @@ class ClassSchedule(models.Model):
     is_absent = models.BooleanField(default=False, help_text="欠席")
     is_tardy = models.BooleanField(default=False, help_text="遅刻")
     note = models.TextField(blank=True, default="", help_text="備考/実施メモ")
-    STATUS_PENDING = 'pending'
-    STATUS_SCHEDULED = 'scheduled'
-    STATUS_DONE = 'done'
+    STATUS_PENDING = "pending"
+    STATUS_SCHEDULED = "scheduled"
+    STATUS_DONE = "done"
     STATUS_CHOICES = [
-        (STATUS_PENDING, '保留'),
-        (STATUS_SCHEDULED, '未実施'),
-        (STATUS_DONE, '実施済'),
+        (STATUS_PENDING, "保留"),
+        (STATUS_SCHEDULED, "未実施"),
+        (STATUS_DONE, "実施済"),
     ]
     status = models.CharField(
-        max_length=10, choices=STATUS_CHOICES,
-        default=STATUS_PENDING, db_index=True, verbose_name='状態'
+        max_length=10,
+        choices=STATUS_CHOICES,
+        default=STATUS_PENDING,
+        db_index=True,
+        verbose_name="状態",
     )
     created_at = models.DateTimeField(auto_now_add=True)
 
     material = models.ForeignKey(
-        TeachingMaterial, on_delete=models.SET_NULL, null=True, blank=True, verbose_name='使用教材'
+        TeachingMaterial, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="使用教材"
     )
     karte_summary = models.CharField(max_length=200, blank=True, verbose_name="授業概要")
     karte_detail = models.TextField(blank=True, verbose_name="授業内容詳細")
@@ -189,8 +219,11 @@ class ClassSchedule(models.Model):
         teacher_name = getattr(self.teacher, "name", "-")
         subject_name = getattr(self.subject, "name", "-")
         return f"{self.class_date} | {self.student.name} | {subject_name} | {teacher_name}"
-    
+
+
 class ClassKarte(models.Model):
+    """授業カルテ（授業内容報告）を保持するモデル。"""
+
     schedule = models.OneToOneField(
         ClassSchedule, on_delete=models.CASCADE, related_name="karte", null=True, blank=True
     )
@@ -250,6 +283,8 @@ class ClassKarte(models.Model):
         return f"{self.class_date} | {self.student.name} | {self.subject} | {self.teacher.name}"
 
 class MaterialUsage(models.Model):
+    """生徒ごとの教材利用履歴。"""
+
     student = models.ForeignKey(StudentProfile, on_delete=models.CASCADE)
     material = models.ForeignKey(TeachingMaterial, on_delete=models.CASCADE)
     used_at = models.DateTimeField(auto_now_add=True)
@@ -259,6 +294,8 @@ class MaterialUsage(models.Model):
 
 
 class DownloadLog(models.Model):
+    """帳票ダウンロード等の操作を記録するログ。"""
+
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True)
     student = models.ForeignKey(StudentProfile, on_delete=models.SET_NULL, null=True, blank=True)
     kind = models.CharField(max_length=50)
@@ -270,18 +307,25 @@ class DownloadLog(models.Model):
 
 
 class AccessLog(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, related_name="personal_access_logs")
+    """閲覧経路やレスポンスコードを残すアクセスログ。"""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name="personal_access_logs",
+    )
     path = models.CharField(max_length=255)
     method = models.CharField(max_length=16)
     student = models.ForeignKey("StudentProfile", null=True, blank=True, on_delete=models.SET_NULL)
     teacher = models.ForeignKey("TeacherProfile", null=True, blank=True, on_delete=models.SET_NULL)
     status_code = models.IntegerField(default=200)
     created_at = models.DateTimeField(auto_now_add=True)
-    
-# 置き場所: personal_info/models.py
-from django.utils import timezone
+
 
 class RewardClosing(models.Model):
+    """報酬締め処理の実行履歴を表す。"""
+
     year = models.IntegerField()
     month = models.IntegerField()
     start_date = models.DateField()
@@ -295,11 +339,14 @@ class RewardClosing(models.Model):
     def __str__(self):
         return f"{self.year}-{self.month:02d} 締め"
 
+
 class RewardClosingTeacher(models.Model):
+    """締め期間内の講師ごとの報酬集計。"""
+
     closing = models.ForeignKey(RewardClosing, on_delete=models.CASCADE, related_name="teachers")
     teacher = models.ForeignKey(TeacherProfile, on_delete=models.PROTECT)
     confirmed_count = models.IntegerField()
-    unit_reward = models.IntegerField(null=True, blank=True)  # 生徒ごとに異なる場合はNone
+    unit_reward = models.IntegerField(null=True, blank=True)  # 生徒ごとに異なる場合は None
     total_reward = models.IntegerField()
 
     def __str__(self):

--- a/teacher_portal/views.py
+++ b/teacher_portal/views.py
@@ -3,8 +3,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.http import HttpResponseForbidden
-# for temporary access tokens via search
-from django.core import signing
+from django.core import signing  # 生徒検索用の一時トークン生成に使用
 from django.core.signing import BadSignature, SignatureExpired
 from personal_info.models import (
     ClassSchedule,
@@ -48,7 +47,7 @@ def _is_teacher(user) -> bool:
 BOM_UTF8 = "\ufeff"
 
 _STUDENT_SEARCH_SALT = "teacher-portal-student-access"
-_STUDENT_SEARCH_MAX_AGE = 300  # seconds (5 minutes)
+_STUDENT_SEARCH_MAX_AGE = 300  # 有効期限は 5 分
 
 
 def _build_student_search_token(user_id: int, student_id: int) -> str:


### PR DESCRIPTION
## Summary
- polish comments and docstrings around personal_info models/forms for clarity
- clean up admin/teacher portal comment wording and add module level description
- refresh README to match current feature set and setup instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf83f2d1288332adcf0639fe78db34