### PR TITLE
Improve error handling for student schedule PDF export

### DIFF
--- a/teacher_portal/pdf_utils.py
+++ b/teacher_portal/pdf_utils.py
@@ -2,6 +2,8 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 from reportlab.lib.utils import simpleSplit
 
+# A4サイズとmm単位はPDF描画の座標計算で頻繁に利用するため、ここで明示的に読み込む。
+
 
 def get_font_name():
     """既存の _register_jp_font を呼び出してフォント名を取得"""

--- a/teacher_portal/views.py
+++ b/teacher_portal/views.py
@@ -17,6 +17,7 @@ from personal_info.models import (
 from personal_info.forms import MaterialList
 from .forms import ClassKarteForm, TeacherScheduleEditForm
 from datetime import date
+import logging
 from django.utils.dateparse import parse_date
 from django.db.models import Q
 from django.core.paginator import Paginator
@@ -624,6 +625,7 @@ def student_schedule_pdf_view(request, student_id: int):
         p.showPage()
         p.save()
     except Exception:
+        # 予期せぬエラー内容を監視できるようログに残し、利用者には共通メッセージを返す。
         logger = logging.getLogger(__name__)
         logger.exception(
             "PDF generation failed",


### PR DESCRIPTION
## Summary
- import Python's logging module in the teacher portal views so PDF生成失敗時に記録できるようにしました
- add a comment in the PDF utility explaining the必須インポート to clarify their目的

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfb0a0a40c8332b8a8085f71799d3d