### PR TITLE
Enable admin material creation

### DIFF
--- a/admin_portal/urls.py
+++ b/admin_portal/urls.py
@@ -21,6 +21,7 @@ from .views import (
                      assignment_bulk_view, assignment_template_csv, attendance_dashboard,
                      assignment_subjects_edit, access_log_list_view,
                      karte_reopen_view, schedule_board_view, karte_pdf_admin, karte_view_admin,
+                     material_create_view,
                      )
 from personal_info.views import edit_schedule_view
 
@@ -34,6 +35,7 @@ urlpatterns = [
     path('schedule/create/', schedule_create_view, name='schedule_create'),
     path('schedule/edit/<int:schedule_id>/', edit_schedule_view, name='edit_schedule'),
     path('schedule/delete/<int:schedule_id>/', delete_schedule_view, name='delete_schedule'),
+    path('materials/create/', material_create_view, name='material_create'),
     path('schedules/<int:schedule_id>/karte/pdf/', karte_pdf_admin, name='karte_pdf_admin'),
     path('schedules/<int:schedule_id>/karte/', karte_view_admin, name='karte_view_admin'),
     path('subjects_delete/<int:subject_id>/', delete_subject, name='delete_subject'),

--- a/admin_portal/views.py
+++ b/admin_portal/views.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.contrib.auth.models import User
 from django.utils.crypto import get_random_string
 from django.http import HttpResponse, HttpResponseForbidden
+from django.urls import reverse
 import os
 import secrets, string
 import sys
@@ -35,7 +36,7 @@ from personal_info.models import (
                                 RewardClosing, RewardClosingTeacher,
                                 TeacherStudentAssignment, ClassKarte,
                                 )
-from personal_info.forms import SubjectForm
+from personal_info.forms import SubjectForm, MaterialList
 from .forms import ClassScheduleForm
 from personal_info.utils import (
     closing_range,
@@ -101,6 +102,7 @@ def admin_dashboard(request):
         return HttpResponseForbidden("権限がありません")
     return render(request, 'admin_portal/admin_dashboard.html')
 
+
 def teacher_register(request):
     if request.method == "POST":
         form = TeacherRegistForm(request.POST)
@@ -144,6 +146,44 @@ def student_register(request):
 def is_admin(user):
     """ログイン済みユーザーが管理者アカウントか判定する。"""
     return user.is_authenticated and hasattr(user, 'userprofile') and user.userprofile.user_type == 'admin'
+
+
+@login_required
+@user_passes_test(is_admin, login_url=None)
+def material_create_view(request):
+    """管理者向け: 教材情報を新規登録する。"""
+
+    next_url = request.POST.get("next") or request.GET.get("next", "")
+
+    if request.method == "POST":
+        form = MaterialList(request.POST)
+        form.fields["subject"].required = True
+        if form.is_valid():
+            material = form.save(commit=False)
+            material.created_by = request.user
+            material.save()
+
+            redirect_to = request.POST.get("next")
+            messages.success(request, "教材を登録しました。")
+            if redirect_to:
+                return redirect(redirect_to)
+            return redirect("personal_info:material_list")
+
+        messages.error(request, "入力内容に不備があります。赤字のエラーをご確認ください。")
+    else:
+        form = MaterialList()
+        form.fields["subject"].required = True
+
+    return render(
+        request,
+        "materials/material_create.html",
+        {
+            "form": form,
+            "next": next_url,
+            "default_back_url": reverse("personal_info:material_list"),
+        },
+    )
+
 
 @login_required
 def delete_schedule_view(request, schedule_id):

--- a/teacher_portal/views.py
+++ b/teacher_portal/views.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.http import HttpResponseForbidden
 from django.core import signing  # 生徒検索用の一時トークン生成に使用
 from django.core.signing import BadSignature, SignatureExpired
+from django.urls import reverse
 from personal_info.models import (
     ClassSchedule,
     MaterialUsage,
@@ -343,7 +344,7 @@ def karte_view(request, schedule_id):
 @login_required
 @user_passes_test(_is_teacher, login_url=None)
 def create_material_view(request):
-    next_url = request.GET.get('next', '')
+    next_url = request.POST.get("next") or request.GET.get("next", "")
     if request.method == 'POST':
         form = MaterialList(request.POST)
         form.fields['subject'].required = True
@@ -351,16 +352,21 @@ def create_material_view(request):
             material = form.save(commit=False)
             material.created_by = request.user
             material.save()
-            redirect_to = request.POST.get('next') or 'teacher_portal:schedule_board'
+            redirect_to = next_url or 'teacher_portal:schedule_board'
             return redirect(redirect_to)
     else:
         form = MaterialList()
         form.fields['subject'].required = True
-    return render(request, 'teacher_portal/material_create.html', {
-        'form': form,
-        'next': next_url,
-        'is_teacher': True,
-    })
+    return render(
+        request,
+        'materials/material_create.html',
+        {
+            'form': form,
+            'next': next_url,
+            'is_teacher': True,
+            'default_back_url': reverse('teacher_portal:schedule_board'),
+        },
+    )
 
 # 講師の担当授業確認（検索つき）
 @login_required

--- a/templates/admin_portal/admin_dashboard.html
+++ b/templates/admin_portal/admin_dashboard.html
@@ -56,6 +56,7 @@
         <div class="d-grid gap-2">
           <a class="btn btn-outline-secondary" href="{% url 'personal_info:subject_list' %}">科目一覧</a>
           <a class="btn btn-outline-secondary" href="{% url 'personal_info:material_list' %}">教材一覧</a>
+          <a class="btn btn-outline-secondary" href="{% url 'admin_portal:material_create' %}">教材を追加</a>
         </div>
       </div>
     </div>

--- a/templates/materials/material_create.html
+++ b/templates/materials/material_create.html
@@ -4,20 +4,19 @@
 {% block content %}
 <h1 class="mb-3">教材を新規登録</h1>
 
-<form method="post">
+<form method="post" novalidate>
   {% csrf_token %}
   {% include "_form_errors.html" %}
 
   {{ form.as_p }}
 
-  {# 戻り先（カルテ編集）を持ち回る #}
   {% if next %}
     <input type="hidden" name="next" value="{{ next }}">
   {% endif %}
 
   <div class="d-flex gap-2 mt-3">
     <button type="submit" class="btn btn-primary">登録</button>
-    <a href="{{ next|default:request.META.HTTP_REFERER }}" class="btn btn-outline-secondary">戻る</a>
+    <a href="{{ next|default:request.META.HTTP_REFERER|default:default_back_url }}" class="btn btn-outline-secondary">戻る</a>
   </div>
 </form>
 {% endblock %}

--- a/templates/personal_info/material_list.html
+++ b/templates/personal_info/material_list.html
@@ -2,6 +2,11 @@
 {% block title %}教材一覧{% endblock %}
 {% block content %}
 <h1 class="h5 mb-3">教材一覧</h1>
+{% if request.user.is_authenticated and request.user.userprofile.user_type == 'admin' %}
+  <div class="d-flex justify-content-end mb-3">
+    <a class="btn btn-primary" href="{% url 'admin_portal:material_create' %}?next={{ request.get_full_path|urlencode }}">教材を追加</a>
+  </div>
+{% endif %}
 <table class="table table-hover table-sm align-middle table-sticky">
   <thead class="table-light"><tr><th>教材名</th><th>科目</th><th>推奨学年</th><th>出版社</th></tr></thead>
   <tbody>

--- a/tests/test_material_create.py
+++ b/tests/test_material_create.py
@@ -48,3 +48,32 @@ def test_teacher_can_create_material_in_demo(client, settings):
 
     assert resp.status_code == 302
     assert TeachingMaterial.objects.filter(title="デモ教材").exists()
+
+
+@pytest.mark.django_db
+def test_admin_can_create_material(client):
+    user = User.objects.create_user(username="A700000", password="AdminPass1!")
+    profile = user.userprofile
+    profile.user_type = "admin"
+    profile.is_temporary_password = False
+    profile.is_locked = False
+    profile.failed_login_attempts = 0
+    profile.save(update_fields=["user_type", "is_temporary_password", "is_locked", "failed_login_attempts"])
+
+    client.force_login(user)
+
+    subject = Subject.objects.create(name="英語")
+
+    resp = client.post(
+        reverse("admin_portal:material_create"),
+        {
+            "title": "管理教材",
+            "subject": subject.id,
+            "grade": "",
+            "publisher": "Admin出版社",
+        },
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith(reverse("personal_info:material_list"))
+    assert TeachingMaterial.objects.filter(title="管理教材").exists()


### PR DESCRIPTION
## Summary
- add an admin-only view and URL for creating teaching materials
- expose entry points from the admin dashboard and material list page
- share the material creation template between admin and teacher flows to keep the UI consistent
- cover admin material creation with a regression test

## Testing
- pytest tests/test_material_create.py

------
https://chatgpt.com/codex/tasks/task_e_68cfba183acc8332bcf57f102b05c033