### PR TITLE
Add GitHub and README links to login page

### DIFF
--- a/templates/core/login.html
+++ b/templates/core/login.html
@@ -19,6 +19,13 @@
         </div>
         <button class="btn btn-primary w-100">ログイン</button>
       </form>
+      <div class="mt-4">
+        <p class="text-muted small mb-2">関連リンク</p>
+        <div class="d-flex flex-column gap-1">
+          <a class="small link-secondary" href="https://github.com/Maybe-navy/home-teach-app-portfolio" target="_blank" rel="noopener">GitHub リポジトリ</a>
+          <a class="small link-secondary" href="https://github.com/Maybe-navy/home-teach-app-portfolio/blob/public/README.md" target="_blank" rel="noopener">README</a>
+        </div>
+      </div>
     </div></div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add a related links section to the login card with shortcuts to the GitHub repository and README

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d268160cc083329a747441bf19406c